### PR TITLE
Use direct import in create-monitor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ipc-monitor",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Observable-based IPC Monitoring Tool",
   "main": "index.js",
   "scripts": {

--- a/src/common/create-monitor.ts
+++ b/src/common/create-monitor.ts
@@ -1,4 +1,6 @@
-import { Observable, Observer, Subscription } from "rxjs";
+import { Observable } from "rxjs/Observable";
+import { Observer } from "rxjs/Observer";
+import { Subscription } from "rxjs/Subscription";
 import { IpcMark } from "./types";
 
 import "rxjs/add/operator/share";


### PR DESCRIPTION
Consumers of this package end up bundling all of RxJS 5 with it. Fixed create-monitor.ts to use direct imports to avoid that