### PR TITLE
fix: require main or renderer parts only when needed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,13 @@
+import "rxjs/add/operator/mergeAll";
 import { Observable } from "rxjs/Observable";
+import { from } from "rxjs/observable/from";
 import { IpcMark } from "./common/types";
 
-import mainProcessMonitor from "./main";
-import rendererProcessMonitor from "./renderer";
-
-const ipcMonitor: Observable<IpcMark> =
-  process?.type === "renderer" ? rendererProcessMonitor : mainProcessMonitor;
+const ipcMonitor: Observable<IpcMark> = from(
+  process?.type === "renderer"
+    ? import("./renderer").then((module) => module.default)
+    : import("./main").then((module) => module.default)
+).mergeAll();
 
 export { IpcMark, IpcMonitor, IpcMetric } from "./common/types";
 export default ipcMonitor;


### PR DESCRIPTION
Requiring the renderer part in the main process leads to an unhandled promise rejection
when it tries to access `window` or `document`.