### PR TITLE
Use Observable to wrap access to window and document object

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ipc-monitor",
-  "version": "1.0.4-beta.0",
+  "version": "1.0.4-beta.1",
   "description": "Observable-based IPC Monitoring Tool",
   "main": "index.js",
   "scripts": {

--- a/src/renderer/dom-observables.ts
+++ b/src/renderer/dom-observables.ts
@@ -32,10 +32,12 @@ export function onDomMutations(
 
 const whenDomReady: Observable<void> = from(
   new Promise((resolve, reject) => {
-    const isUndefined = (obj: any) =>
-      typeof obj === "undefined" || obj === undefined || obj === null;
-    if (isUndefined(window) || isUndefined(document)) {
-      reject(new Error("Global Window/DOM not present"));
+    if (typeof window === "undefined") {
+      reject(new Error("Global Window not present"));
+      return;
+    }
+    if (typeof document === "undefined") {
+      reject(new Error("Global Document not present"));
       return;
     }
 


### PR DESCRIPTION
This should avoid any unhandled exceptions in the future within the DOMReady event.